### PR TITLE
Encode LF in #.fmfn

### DIFF
--- a/Functions/#Name-Value/#.fmfn
+++ b/Functions/#Name-Value/#.fmfn
@@ -32,6 +32,9 @@
  *		MODIFIED on 2012-11-28 by Jeremy Bante <http://scr.im/jbante> to return
  *		error feedback, and to prefix names with "$".
  *		CREATED on 2012-11-10 by Jeremy Bante <http://scr.im/jbante>.
+ *
+ * REFERENCES:
+ *		https://github.com/filemakerstandards/fmpstandards/blob/working/Functions/%23Name-Value/%23.fmfn
  * =====================================
  */
 
@@ -67,7 +70,7 @@ Let ( [
 				"GetAsDate ( " & Quote ( value ) & " )" ;
 
 			~text ≠ GetAsText ( ~number ) ;
-				Quote ( value ) ;
+				Substitute ( Quote ( value ) ; Char ( 10 ) ; Quote ( " & Char ( 10 ) & " ) ) ;
 
 			/* Else */
 				~number


### PR DESCRIPTION
FileMaker's Value functions treat CR and LF as equivalent, but the Quote function does not.  There's no FileMaker escape sequence for LF.  For example:

```
ValueCount ( Quote ( Quote ( List ( "a" ; "b" ; Char ( 10 ) ; "c" ) ) ) ) // Returns 2, expected 1
```

As a result, # will return invalid Let notation for values containing LF.  This problem doesn't appear when using #Get, which doesn't rely on value list processing.  However, #Filter fails spectacularly on this invalid result.

The trick is to encode LF.  We can do this similarly to how we encode timestmaps.  We Substitute LF for a string concatenation with "Char ( 10 )".

https://github.com/filemakerstandards/fmpstandards/issues/7
