### PR TITLE
Modify # function to detect long sequences

### DIFF
--- a/Functions/#Name-Value/#.fmfn
+++ b/Functions/#Name-Value/#.fmfn
@@ -16,6 +16,8 @@
  * DEPENDENCIES: none
  *
  * HISTORY:
+ *		MODIFIED on 2017-08-31 by Nick Lewis nilness@gmail.com to fix an
+ *		issue where long sequences of text could be interpreted as numbers.
  *		MODIFIED on 2014-10-07 by Daniel Smith dansmith65@gmail.com to prevent
  *		from returning an EvaluationError.
  *		MODIFIED on 2014-06-06 by Jeremy Bante <http://scr.im/jbante> to fix an
@@ -63,7 +65,7 @@ Let ( [
 	~number = GetAsNumber ( value ) ;
 	~value =
 		Case (
-			value = "" or value = "?" or ~number = "?" ;
+			value = "" or value = "?" or ~number = "?" or number = "";
 				Quote ( value ) ;
 
 			~isValidDate


### PR DESCRIPTION
Long sequences (like a Base64 encoding) are returning an error. 

In line #63, GetAsNumber ( Base64 encoding) is returning "", but in line #82 the comparison "value ≠ ~number" is returning False, so ~value is set to ~number which is empty.

I found two solutions, changing the comparison in line #82 to "value ≠ GetAsNumber ( ~number ) ;", or in line #66 adding " or number = "" " to the first Case test that assigns to "~value". 

I suggest the first as it will short circuit the Case tests preventing unneeded comparisons.

Does it cause a problem? It seems that it could only cause a problem if it causes Date/Time/Timestamp/Number detection to be fail. The only way it could do that is if GetAsNumber (Date/Time/Timestamp/Number) returned an empty string, and I can't see where that could happen.

My limited testing confirms this, but further testing/brighter minds may see something I don't.